### PR TITLE
fix(skills): remove design filter

### DIFF
--- a/src/container/Skills/Skills.jsx
+++ b/src/container/Skills/Skills.jsx
@@ -15,7 +15,6 @@ const queryList = [
   "database",
   "frameworks",
   "tools",
-  "design",
 ];
 
 const Skills = () => {


### PR DESCRIPTION
Removing the "design" filter button in Skills page, since data has been removed from back-end